### PR TITLE
Fix #1: added script link and hotkey script

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 </html>
 
 <script src="https://unpkg.com/filer/dist/filer.min.js"></script>
+<script src="https://unpkg.com/hotkeys-js/dist/hotkeys.min.js"></script>
        
 <script> 
      const fd = new Filer.FileSystem(); 
@@ -43,4 +44,12 @@
                 });
      }
 
-</script>   
+</script>  
+<script type="text/javascript">
+    hotkeys('alt+s', function (event, handler){
+      if (handler.key == 'alt+s') {
+        saveNote();
+        console.log("alt+s")
+      }
+    });
+</script>


### PR DESCRIPTION
### Feature
Now users can save their note by pressing alt+s.

### How it works
1. Included script link from hotkeys.js library <script src="https://unpkg.com/hotkeys-js/dist/hotkeys.min.js"></script>
2. Included hotkey script which calls your function saveNote() when alt+s is pressed.

